### PR TITLE
revert tempo version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   tempo:
-    image: grafana/tempo:main-bd4e88a
+    image: grafana/tempo:2.9.0
     hostname: tempo
     container_name: tempo
     restart: always


### PR DESCRIPTION
Latest tempo versions has breaking changes that prevents use of current configuration files. Reverting back to older version until configuration can be updated.