### PR TITLE
Upgrade grafana stack

### DIFF
--- a/grafana-dashboards/README.md
+++ b/grafana-dashboards/README.md
@@ -137,7 +137,7 @@ If you encounter any issues, it is recommended that you review the docker-compos
 ### Prerequisites
 
 - [Z Observability Connect Telemetry Controller](https://www.ibm.com/docs/en/zapmc/7.1.0?topic=z-observability-connect-overview)
-- [Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) (tested with 11.4.6)
+- [Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) (tested with 13.0.1)
 - [Loki](https://grafana.com/docs/loki/latest/setup/install/)
 - [Prometheus](https://prometheus.io/docs/prometheus/latest/installation/)
 

--- a/grafana-dashboards/config/tools/tempo.yml
+++ b/grafana-dashboards/config/tools/tempo.yml
@@ -1,43 +1,42 @@
+stream_over_http_enabled: true
+
 server:
-    http_listen_port: 3200
+  http_listen_port: 3200
+  log_level: info
 
 distributor:
-    receivers:
-        otlp:
-            protocols:
-                http:
-                    endpoint: 0.0.0.0:4318
-                grpc:
-                    endpoint: 0.0.0.0:4317
-
-ingester:
-    max_block_duration: 5m
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+        http:
+          endpoint: "tempo:4318"
 
 metrics_generator:
-    processor:
-        service_graphs:
-            wait: 10s
-    registry:
-        external_labels:
-            source: tempo
-    storage:
-        path: /tmp/tempo/generator/wal
-        remote_write:
-            - url: http://prometheus:9090/api/v1/write
-              send_exemplars: true
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
 
 storage:
-    trace:
-        backend: local
-        wal:
-            path: /tmp/tempo/wal
-        local:
-            path: /tmp/tempo/blocks
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
 
 overrides:
-    ingestion_rate_limit_bytes: 150000000
-    ingestion_burst_size_bytes: 200000000
-    max_bytes_per_trace: 50000000
-    metrics_generator_processors:
-        - service-graphs
-        - span-metrics
+  defaults:
+    metrics_generator:
+      processors: ["span-metrics", "service-graphs"]
+      generate_native_histograms: both
+
+usage_report:
+  reporting_enabled: false

--- a/grafana-dashboards/docker-compose.yaml
+++ b/grafana-dashboards/docker-compose.yaml
@@ -1,22 +1,21 @@
 services:
-
   tempo:
-    image: grafana/tempo:2.9.0
+    image: grafana/tempo:3.0.0
     hostname: tempo
     container_name: tempo
     restart: always
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    command: "-target=all -config.file=/etc/tempo.yaml"
     volumes:
       - ./config/tools/tempo.yml:/etc/tempo.yaml:Z
-      - ./tempo-data:/var/tempo:Z
+      - tempo-data:/var/tempo:Z
     ports:
-      - "14268"  # jaeger ingest
-      - "3200"   # tempo
-      - "4317:4317"  # otlp grpc
-      - "4318:4318"  # otlp http
-      
+      - "14268" # jaeger ingest
+      - "3200" # tempo
+      - "4317:4317" # otlp grpc
+      - "4318:4318" # otlp http
+
   prometheus:
-    image: quay.io/prometheus/prometheus:v3.9.1
+    image: quay.io/prometheus/prometheus:v3.12.0
     container_name: prometheus
     command:
       - --config.file=/etc/prometheus.yml
@@ -27,7 +26,7 @@ services:
       - 9090:9090
 
   loki:
-    image: grafana/loki:3.4.1
+    image: grafana/loki:3.7.2
     container_name: loki
     ports:
       - "3100:3100"
@@ -36,7 +35,7 @@ services:
       - ./config/tools/loki-config.yaml:/etc/loki/local-config.yaml:Z
 
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:13.0.1-security-01
     container_name: grafana
     restart: unless-stopped
     volumes:
@@ -59,3 +58,4 @@ services:
 
 volumes:
   grafana-storage: {}
+  tempo-data: {}


### PR DESCRIPTION
# What change does this PR introduce?

- Updates our docker compose file (and tempo config) to use the latest versions available at the time of writing this PR.

# Why is this change being made?

- Many of the used Grafana stack image versions were out of date which led to numerous CVEs being opened on them which caused issues for VMs that used them. 
- We were unable to use newer features, like drilldown, in the older image versions

# How has this been tested?

Reinstalled the Grafana stack using the docker images listed in the new docker compose. Ensured that dashboards and Grafana plugins worked and could receive data using mock telemetry